### PR TITLE
Add some Prometheus metrics

### DIFF
--- a/algo_consistent.go
+++ b/algo_consistent.go
@@ -14,6 +14,9 @@ const (
 
 // ConsistentConfig holds the configuration for the Consistent hash algorithm.
 type ConsistentConfig struct {
+	// Name used for metrics and reporting
+	Name string
+
 	// Hash is the hashing function used for hash Endpoints and keys onto the hash
 	// ring. You may want to use an interesting hash function like xxHash.
 	// Defaults to CRC32.
@@ -43,6 +46,7 @@ type endpointInfo struct {
 // Consistent implements a consistent hashing algorithm.
 type Consistent struct {
 	sync.Mutex
+	name         string
 	hash         Hash
 	replicas     int
 	numEndpoints int
@@ -58,6 +62,7 @@ var _ EndpointSet = &Consistent{}
 // NewConsistent creates a new Consistent object.
 func NewConsistent(config ConsistentConfig) *Consistent {
 	c := &Consistent{
+		name:       config.Name,
 		replicas:   config.ReplicationCount,
 		loadFactor: config.LoadFactor,
 		hash:       config.Hash,


### PR DESCRIPTION
Add Prometheus metrics to let operators see what is going on inside the consistent hash balancer.

Metrics are put in a namespace taken from the name of the program so, if you link this library into a program called `frontend`, you will get these metrics:

metric | description
-|-
frontend_lb_requests_inflight | Total number of requests in-flight
frontend_lb_endpoints | Number of endpoints for this service
frontend_lb_requests_total | Number of processed requests
frontend_lb_requests_overflowed_total | Number of requests that overflowed the load factor

Each has a label `name` so that different balancers within the program have their own metrics.

(I did this about 8 months ago and coming back to it I find several aspects of the design questionable; I was generally going for minimal disruption to APIs but maybe went too far.  Let me know what you think.)